### PR TITLE
Merge different prefix options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ Edit `/etc/sensu/conf.d/statsd.json` to change its configuration.
 |flush_interval|integer|10|The StatsD flush interval|
 |send_interval|integer|30|How often Graphite metrics are sent to Sensu|
 |percentile|integer|90|The percentile to calculate for StatsD metrics|
-|add_client_prefix|boolean|true|If the Sensu client name should prefix the Graphite metric path|
-|path_prefix|string|"statsd"|The optional Graphite metric path prefix (after client name)|
-|add_path_prefix|boolean|true|If the path_prefix should be used|
+|path_prefix|string|"statsd"|The optional Graphite metric path prefix|
 |handler|string|"graphite"|Handler to use for the Graphite metrics|
 
 ## Example

--- a/lib/sensu/extensions/statsd.rb
+++ b/lib/sensu/extensions/statsd.rb
@@ -27,9 +27,7 @@ module Sensu
           :flush_interval => 10,
           :send_interval => 30,
           :percentile => 90,
-          :add_client_prefix => true,
           :path_prefix => "statsd",
-          :add_path_prefix => true,
           :handler => "graphite"
         }
         @options.merge!(@settings[:statsd]) if @settings[:statsd].is_a?(Hash)
@@ -74,8 +72,7 @@ module Sensu
       def add_metric(*args)
         value = args.pop
         path = []
-        path << @settings[:client][:name] if options[:add_client_prefix]
-        path << options[:path_prefix] if options[:add_path_prefix]
+        path << options[:path_prefix].split(".")
         path = (path + args).join(".")
         if path !~ /^[A-Za-z0-9\._-]*$/
           @logger.info("invalid statsd metric", {

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -42,8 +42,8 @@ describe "Sensu::Extension::StatsD" do
         end
         timer(3) do
           @extension.safe_run do |output, status|
-            expect(output).to match(/foo\.statsd\.gauges\.tcp 1\.0/)
-            expect(output).to match(/foo\.statsd\.gauges\.udp 2\.0/)
+            expect(output).to match(/statsd\.gauges\.tcp 1\.0/)
+            expect(output).to match(/statsd\.gauges\.udp 2\.0/)
             expect(status).to eq(0)
             async_done
           end


### PR DESCRIPTION
Reopened pull request #1 with different source branch:

> Currently the the following options are available for prefixing the metric names:
> 
> * add_client_prefix
> * path_prefix
> * add_path_prefix
> 
> In my opinion, these could be simplified by just using a single option path_prefix, like this pull request suggests. In the current state, we would lose the ability to include the client name, tough.
> 
> I had the idea to add support for token substitution, like it is possible in check configurations, but I don't know if that is possible. If it was, we could mimic the current behavior using a default for path_prefix like this: :::name:::.statsd. Suggestions are welcome.