### PR TITLE
Fix gauge implementation

### DIFF
--- a/lib/sensu/extensions/statsd.rb
+++ b/lib/sensu/extensions/statsd.rb
@@ -139,7 +139,13 @@ module Sensu
             name, value = nv.split(":")
             case type
             when "g"
-              @gauges[name] = Float(value)
+              if value.start_with? '+'
+                @gauges[name] += Float(value)
+              elsif value.start_with? '-'
+                @gauges[name] -= Float(value)
+              else
+                @gauges[name] = Float(value)
+              end
             when /^c/, "m"
               _, raw_sample = type.split("@")
               sample = (raw_sample ? Float(raw_sample) : 1)

--- a/lib/sensu/extensions/statsd.rb
+++ b/lib/sensu/extensions/statsd.rb
@@ -96,7 +96,6 @@ module Sensu
         @gauges.each do |name, value|
           add_metric("gauges", name, value)
         end
-        @gauges.clear
         @counters.each do |name, value|
           add_metric("counters", name, value)
         end


### PR DESCRIPTION
I identified two issues with the implementation of gauges compared to Etsy's specification at https://github.com/etsy/statsd/blob/master/docs/metric_types.md#gauges:
* Gauges should not be reset on flush. They are supposed to keep their last value (unlike counters).
* Relative gauge values are currently not supported. If gauge values are prefixed by '+' or '-', it should add or subtract the amount from the current value.

Both issues are fixed by this pull request.